### PR TITLE
Bump version to 1.3.2

### DIFF
--- a/logtool/pom.xml
+++ b/logtool/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.powertac</groupId>
     <artifactId>server-master</artifactId>
-    <version>1.3.1-SNAPSHOT</version>
+    <version>1.3.2-SNAPSHOT</version>
     <relativePath />
   </parent>
 
@@ -35,22 +35,22 @@
     <dependency>
       <groupId>org.powertac</groupId>
       <artifactId>default-broker</artifactId>
-      <version>1.3.1-SNAPSHOT</version>
+      <version>1.3.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.powertac</groupId>
       <artifactId>genco</artifactId>
-      <version>1.3.1-SNAPSHOT</version>
+      <version>1.3.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.powertac</groupId>
       <artifactId>evcustomer</artifactId>
-      <version>1.3.1-SNAPSHOT</version>
+      <version>1.3.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.powertac</groupId>
       <artifactId>customer-models</artifactId>
-      <version>1.3.1-SNAPSHOT</version>
+      <version>1.3.2-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.powertac</groupId>
       <artifactId>server-interface</artifactId>
-      <version>1.3.1-SNAPSHOT</version>
+      <version>1.3.2-SNAPSHOT</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The new visualizer has a dependency on logtool, would be convenient if it has the same version as all of the other powertac dependencies.